### PR TITLE
feat: Reflow vs Repaint 실험 구현 및 리액트 렌더링 최적화

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Layout from './components/Layout';
 import Home from './pages/Home';
+import ReflowRepaint from './experiments/rendering/reflow-repaint/index';
 
 function App() {
     return (
@@ -9,6 +10,7 @@ function App() {
             <Routes>
                 <Route path="/" element={<Layout />}>
                     <Route index element={<Home />} />
+                    <Route path="experiments/rendering/reflow-repaint" element={<ReflowRepaint />} />
                     <Route path="*" element={<Navigate to="/" replace />} />
                 </Route>
             </Routes>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -115,8 +115,7 @@ const Layout = () => {
             </aside>
 
             {/* 🖥️ Main Content Area */}
-            <main className="flex-1 flex flex-col h-full overflow-hidden relative w-full">
-                {/* Top Header */}
+            <main className="flex-1 flex flex-col h-full overflow-hidden relative w-full pt-16 md:pt-0">                {/* Top Header */}
                 <header className="hidden md:flex items-center justify-between h-16 px-8 bg-white/80 backdrop-blur-md border-b border-gray-200 sticky top-0 z-10">
                     <div className="flex items-center text-sm text-slate-500">
                         <span className="hover:text-blue-600 cursor-pointer transition-colors" onClick={() => navigate('/')}>Home</span>

--- a/src/experiments/rendering/reflow-repaint/index.jsx
+++ b/src/experiments/rendering/reflow-repaint/index.jsx
@@ -1,0 +1,202 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Stats from 'stats.js';
+import { Play, Pause, RefreshCw, AlertTriangle, CheckCircle, Cpu, Zap, Loader2 } from 'lucide-react';
+
+const ITEM_COUNT = 3000;
+
+const ReflowRepaint = () => {
+    const [isRunning, setIsRunning] = useState(false);
+    const [isOptimized, setIsOptimized] = useState(false); // false: CPU, true: GPU
+    const [isSwitching, setIsSwitching] = useState(false); // 전환 애니메이션 상태
+
+    const containerRef = useRef(null);
+    const requestRef = useRef();
+    const statsRef = useRef(null);
+
+    // 1. Stats.js 초기화
+    useEffect(() => {
+        if (!statsRef.current && containerRef.current) {
+            const stats = new Stats();
+            stats.showPanel(0); // FPS
+            stats.dom.style.position = 'absolute';
+            stats.dom.style.top = '10px';
+            stats.dom.style.left = '10px';
+            stats.dom.style.zIndex = '20';
+            containerRef.current.appendChild(stats.dom);
+            statsRef.current = stats;
+        }
+    }, []);
+
+    // 2. 엔진 모드 변경 핸들러 (전환 효과 추가)
+    const handleModeToggle = () => {
+        if (isSwitching) return;
+
+        setIsSwitching(true);
+        setIsRunning(false);
+        setIsOptimized((prev) => !prev);
+        setIsSwitching(false);
+    };
+
+    // 3. 애니메이션 루프
+    const animate = (time) => {
+        if (statsRef.current) statsRef.current.begin();
+
+        const items = document.getElementsByClassName('test-item');
+        // 0 ~ 300px 사이 왕복 운동
+        const position = (Math.sin(time / 500) + 1) * 150;
+
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (isOptimized) {
+                // ✅ GPU: transform
+                item.style.transform = `translateX(${position}px)`;
+            } else {
+                // ❌ CPU: left
+                item.style.left = `${position}px`;
+            }
+        }
+
+        if (statsRef.current) statsRef.current.end();
+        requestRef.current = requestAnimationFrame(animate);
+    };
+
+    // 실행/중지 컨트롤
+    useEffect(() => {
+        if (isRunning && !isSwitching) {
+            requestRef.current = requestAnimationFrame(animate);
+        } else {
+            cancelAnimationFrame(requestRef.current);
+        }
+        return () => cancelAnimationFrame(requestRef.current);
+    }, [isRunning, isOptimized, isSwitching]);
+
+    return (
+        <div className="space-y-6">
+            {/* 🎛️ Header & Controls */}
+            <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm space-y-6">
+                <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+                    <div>
+                        <h2 className="text-2xl font-bold text-gray-900 flex flex-wrap items-center gap-2">
+                            Reflow vs Repaint
+                            <span className="text-sm font-normal text-gray-500 bg-gray-100 px-2 py-1 rounded-full whitespace-nowrap">
+                Day 1
+              </span>
+                        </h2>
+                        <p className="text-gray-500 mt-1">
+                            CSS 속성에 따른 렌더링 파이프라인 부하 차이를 비교합니다.
+                        </p>
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        {/* Play/Pause Button */}
+                        <button
+                            onClick={() => setIsRunning(!isRunning)}
+                            disabled={isSwitching}
+                            className={`flex items-center gap-2 px-5 py-2.5 rounded-lg font-bold text-white transition-all shadow-md active:scale-95 ${
+                                isRunning
+                                    ? 'bg-orange-500 hover:bg-orange-600 shadow-orange-200'
+                                    : 'bg-blue-600 hover:bg-blue-700 shadow-blue-200'
+                            } disabled:opacity-50 disabled:cursor-not-allowed`}
+                        >
+                            {isRunning ? <Pause size={20} fill="currentColor" /> : <Play size={20} fill="currentColor" />}
+                            {isRunning ? 'Pause' : 'Start'}
+                        </button>
+
+                        <button
+                            onClick={() => window.location.reload()}
+                            className="p-2.5 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors border border-gray-200"
+                            title="Reset"
+                        >
+                            <RefreshCw size={20} />
+                        </button>
+                    </div>
+                </div>
+
+                {/* 🕹️ Toggle Switch UI (New) */}
+                <div className="flex flex-col sm:flex-row gap-4 items-center justify-between p-4 bg-slate-50 rounded-lg border border-slate-200">
+                    <div className="flex items-center gap-3">
+                        <div className={`p-2 rounded-lg ${isOptimized ? 'bg-green-100 text-green-600' : 'bg-red-100 text-red-600'}`}>
+                            {isOptimized ? <Zap size={24} /> : <Cpu size={24} />}
+                        </div>
+                        <div>
+                            <div className="font-bold text-slate-800">
+                                {isOptimized ? 'GPU Accelerated' : 'CPU Software Mode'}
+                            </div>
+                            <div className="text-xs text-slate-500">
+                                {isOptimized ? 'Composite Layer Only' : 'Triggers Reflow & Layout'}
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Custom Toggle Switch */}
+                    <button
+                        onClick={handleModeToggle}
+                        disabled={isSwitching}
+                        className={`relative w-64 h-12 rounded-full p-1 transition-colors duration-300 ease-in-out cursor-pointer shadow-inner ${
+                            isOptimized ? 'bg-green-500' : 'bg-red-400'
+                        }`}
+                    >
+                        <div className="absolute inset-0 flex justify-between items-center px-4 text-xs font-bold text-white pointer-events-none uppercase tracking-wider">
+                            <span>Slow (CPU)</span>
+                            <span>Fast (GPU)</span>
+                        </div>
+                        <div
+                            className={`absolute top-1 bottom-1 w-[48%] bg-white rounded-full shadow-md transform transition-transform duration-300 ease-out flex items-center justify-center ${
+                                isOptimized ? 'translate-x-[104%]' : 'translate-x-0'
+                            }`}
+                        >
+                            {isSwitching ? (
+                                <Loader2 size={16} className="animate-spin text-gray-400" />
+                            ) : (
+                                <div className={`w-2 h-8 rounded-full ${isOptimized ? 'bg-green-500' : 'bg-red-400'}`} />
+                            )}
+                        </div>
+                    </button>
+                </div>
+
+                {/* Info Box */}
+                <div className={`p-4 rounded-lg border text-sm transition-colors duration-300 ${isOptimized ? 'bg-green-50 border-green-200 text-green-800' : 'bg-red-50 border-red-200 text-red-800'}`}>
+                    <strong>💡 이론:</strong> {isOptimized
+                    ? 'transform 속성은 메인 스레드의 레이아웃 계산(Reflow)을 건너뛰고, GPU가 처리하는 합성(Composite) 단계만 수행합니다.'
+                    : 'left/top 속성을 변경하면 브라우저가 모든 픽셀의 위치를 재계산(Reflow)하느라 CPU 자원을 심하게 소모합니다.'}
+                </div>
+            </div>
+
+            {/* Animation Stage */}
+            <div
+                ref={containerRef}
+                className="relative h-[500px] bg-slate-900 rounded-xl overflow-hidden border border-slate-800 shadow-2xl ring-1 ring-slate-900/5"
+            >
+                {/* Loading Overlay */}
+                {isSwitching && (
+                    <div className="absolute inset-0 z-30 bg-black/60 backdrop-blur-sm flex flex-col items-center justify-center text-white">
+                        <Loader2 size={48} className="animate-spin text-blue-500 mb-4" />
+                        <div className="text-xl font-bold">Switching Rendering Engine...</div>
+                        <div className="text-sm text-slate-400 mt-2">Flush Layout Cache & Optimizing Layers</div>
+                    </div>
+                )}
+
+                <div className="absolute top-4 right-4 z-10 bg-black/50 backdrop-blur px-3 py-1 rounded-full text-xs text-slate-300 font-mono border border-white/10">
+                    Object Count: {ITEM_COUNT}
+                </div>
+
+                {/* Test Items */}
+                {Array.from({ length: ITEM_COUNT }).map((_, i) => (
+                    <div
+                        key={i}
+                        className="test-item absolute w-6 h-6 rounded-full shadow-lg"
+                        style={{
+                            top: `${Math.random() * 90 + 5}%`, // 상하 여백 둠
+                            left: '50px',
+                            background: `hsl(${Math.random() * 360}, 70%, 60%)`,
+                            willChange: isOptimized ? 'transform' : 'auto',
+                            opacity: 0.8
+                        }}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default ReflowRepaint;

--- a/src/experiments/rendering/reflow-repaint/index.jsx
+++ b/src/experiments/rendering/reflow-repaint/index.jsx
@@ -1,23 +1,51 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useTransition } from 'react';
 import Stats from 'stats.js';
-import { Play, Pause, RefreshCw, AlertTriangle, CheckCircle, Cpu, Zap, Loader2 } from 'lucide-react';
+import { Play, Pause, RefreshCw, Zap, Cpu, Loader2 } from 'lucide-react';
 
 const ITEM_COUNT = 3000;
 
+// React.memo로 최적화된 아이템 레이어
+const TestItemLayer = React.memo(({ isOptimized, count }) => {
+    return (
+        <>
+            {Array.from({ length: count }).map((_, i) => (
+                <div
+                    key={i}
+                    className="test-item absolute w-6 h-6 rounded-full shadow-lg"
+                    style={{
+                        top: `${Math.random() * 90 + 5}%`,
+                        left: '50px',
+                        background: `hsl(${Math.random() * 360}, 70%, 60%)`,
+                        willChange: isOptimized ? 'transform' : 'auto',
+                        opacity: 0.8,
+                        transform: 'translate3d(0,0,0)'
+                    }}
+                />
+            ))}
+        </>
+    );
+}, (prevProps, nextProps) => {
+    return prevProps.isOptimized === nextProps.isOptimized;
+});
+
 const ReflowRepaint = () => {
     const [isRunning, setIsRunning] = useState(false);
-    const [isOptimized, setIsOptimized] = useState(false); // false: CPU, true: GPU
-    const [isSwitching, setIsSwitching] = useState(false); // 전환 애니메이션 상태
+    const [isOptimized, setIsOptimized] = useState(false);
+
+    // ✅ [핵심 변경] React 18의 동시성 모드 훅 사용
+    // isPending: 작업이 진행 중일 때 자동으로 true가 됨
+    // startTransition: 무거운 상태 업데이트를 래핑하는 함수
+    const [isPending, startTransition] = useTransition();
 
     const containerRef = useRef(null);
     const requestRef = useRef();
     const statsRef = useRef(null);
 
-    // 1. Stats.js 초기화
+    // Stats 초기화
     useEffect(() => {
         if (!statsRef.current && containerRef.current) {
             const stats = new Stats();
-            stats.showPanel(0); // FPS
+            stats.showPanel(0);
             stats.dom.style.position = 'absolute';
             stats.dom.style.top = '10px';
             stats.dom.style.left = '10px';
@@ -27,31 +55,28 @@ const ReflowRepaint = () => {
         }
     }, []);
 
-    // 2. 엔진 모드 변경 핸들러 (전환 효과 추가)
+    // ✅ [핵심 변경] setTimeout 제거 및 startTransition 적용
     const handleModeToggle = () => {
-        if (isSwitching) return;
+        if (isPending) return;
 
-        setIsSwitching(true);
-        setIsRunning(false);
-        setIsOptimized((prev) => !prev);
-        setIsSwitching(false);
+        setIsRunning(false); // 애니메이션 멈춤 (즉시 반영)
+
+        // 무거운 렌더링(3000개 업데이트)을 트랜지션으로 감싸서 백그라운드 처리
+        startTransition(() => {
+            setIsOptimized((prev) => !prev);
+        });
     };
 
-    // 3. 애니메이션 루프
     const animate = (time) => {
         if (statsRef.current) statsRef.current.begin();
-
         const items = document.getElementsByClassName('test-item');
-        // 0 ~ 300px 사이 왕복 운동
         const position = (Math.sin(time / 500) + 1) * 150;
 
-        for (let i = 0; i < items.length; i++) {
+        for (let i = 0, len = items.length; i < len; i++) {
             const item = items[i];
             if (isOptimized) {
-                // ✅ GPU: transform
-                item.style.transform = `translateX(${position}px)`;
+                item.style.transform = `translate3d(${position}px, 0, 0)`;
             } else {
-                // ❌ CPU: left
                 item.style.left = `${position}px`;
             }
         }
@@ -60,27 +85,25 @@ const ReflowRepaint = () => {
         requestRef.current = requestAnimationFrame(animate);
     };
 
-    // 실행/중지 컨트롤
     useEffect(() => {
-        if (isRunning && !isSwitching) {
+        if (isRunning && !isPending) {
             requestRef.current = requestAnimationFrame(animate);
         } else {
             cancelAnimationFrame(requestRef.current);
         }
         return () => cancelAnimationFrame(requestRef.current);
-    }, [isRunning, isOptimized, isSwitching]);
+    }, [isRunning, isOptimized, isPending]);
 
     return (
         <div className="space-y-6">
-            {/* 🎛️ Header & Controls */}
             <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm space-y-6">
                 <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                     <div>
                         <h2 className="text-2xl font-bold text-gray-900 flex flex-wrap items-center gap-2">
                             Reflow vs Repaint
                             <span className="text-sm font-normal text-gray-500 bg-gray-100 px-2 py-1 rounded-full whitespace-nowrap">
-                Day 1
-              </span>
+                                Day 1
+                            </span>
                         </h2>
                         <p className="text-gray-500 mt-1">
                             CSS 속성에 따른 렌더링 파이프라인 부하 차이를 비교합니다.
@@ -88,10 +111,9 @@ const ReflowRepaint = () => {
                     </div>
 
                     <div className="flex items-center gap-3">
-                        {/* Play/Pause Button */}
                         <button
                             onClick={() => setIsRunning(!isRunning)}
-                            disabled={isSwitching}
+                            disabled={isPending}
                             className={`flex items-center gap-2 px-5 py-2.5 rounded-lg font-bold text-white transition-all shadow-md active:scale-95 ${
                                 isRunning
                                     ? 'bg-orange-500 hover:bg-orange-600 shadow-orange-200'
@@ -101,18 +123,15 @@ const ReflowRepaint = () => {
                             {isRunning ? <Pause size={20} fill="currentColor" /> : <Play size={20} fill="currentColor" />}
                             {isRunning ? 'Pause' : 'Start'}
                         </button>
-
                         <button
                             onClick={() => window.location.reload()}
                             className="p-2.5 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors border border-gray-200"
-                            title="Reset"
                         >
                             <RefreshCw size={20} />
                         </button>
                     </div>
                 </div>
 
-                {/* 🕹️ Toggle Switch UI (New) */}
                 <div className="flex flex-col sm:flex-row gap-4 items-center justify-between p-4 bg-slate-50 rounded-lg border border-slate-200">
                     <div className="flex items-center gap-3">
                         <div className={`p-2 rounded-lg ${isOptimized ? 'bg-green-100 text-green-600' : 'bg-red-100 text-red-600'}`}>
@@ -128,33 +147,32 @@ const ReflowRepaint = () => {
                         </div>
                     </div>
 
-                    {/* Custom Toggle Switch */}
                     <button
                         onClick={handleModeToggle}
-                        disabled={isSwitching}
-                        className={`relative w-64 h-12 rounded-full p-1 transition-colors duration-300 ease-in-out cursor-pointer shadow-inner ${
+                        disabled={isPending}
+                        className={`relative w-48 h-12 rounded-full p-1 transition-colors duration-300 ease-in-out cursor-pointer shadow-inner ${
                             isOptimized ? 'bg-green-500' : 'bg-red-400'
                         }`}
                     >
                         <div className="absolute inset-0 flex justify-between items-center px-4 text-xs font-bold text-white pointer-events-none uppercase tracking-wider">
-                            <span>Slow (CPU)</span>
-                            <span>Fast (GPU)</span>
+                            <span>Use CPU</span>
+                            <span>Use GPU</span>
                         </div>
                         <div
-                            className={`absolute top-1 bottom-1 w-[48%] bg-white rounded-full shadow-md transform transition-transform duration-300 ease-out flex items-center justify-center ${
+                            className={`absolute top-1 bottom-1 w-[47%] bg-white rounded-full shadow-md transform transition-transform duration-200 ease-out flex items-center justify-center ${
                                 isOptimized ? 'translate-x-[104%]' : 'translate-x-0'
                             }`}
                         >
-                            {isSwitching ? (
+                            {/* ✅ 로딩 애니메이션 조건 변경 */}
+                            {isPending ? (
                                 <Loader2 size={16} className="animate-spin text-gray-400" />
                             ) : (
-                                <div className={`w-2 h-8 rounded-full ${isOptimized ? 'bg-green-500' : 'bg-red-400'}`} />
+                                <div className={`w-2 h-8 rounded-full transition-colors duration-300 ease-in-out ${isOptimized ? 'bg-green-500' : 'bg-red-400'}`} />
                             )}
                         </div>
                     </button>
                 </div>
 
-                {/* Info Box */}
                 <div className={`p-4 rounded-lg border text-sm transition-colors duration-300 ${isOptimized ? 'bg-green-50 border-green-200 text-green-800' : 'bg-red-50 border-red-200 text-red-800'}`}>
                     <strong>💡 이론:</strong> {isOptimized
                     ? 'transform 속성은 메인 스레드의 레이아웃 계산(Reflow)을 건너뛰고, GPU가 처리하는 합성(Composite) 단계만 수행합니다.'
@@ -162,17 +180,16 @@ const ReflowRepaint = () => {
                 </div>
             </div>
 
-            {/* Animation Stage */}
             <div
                 ref={containerRef}
                 className="relative h-[500px] bg-slate-900 rounded-xl overflow-hidden border border-slate-800 shadow-2xl ring-1 ring-slate-900/5"
             >
-                {/* Loading Overlay */}
-                {isSwitching && (
+                {/* ✅ 로딩 오버레이 조건 변경 */}
+                {isPending && (
                     <div className="absolute inset-0 z-30 bg-black/60 backdrop-blur-sm flex flex-col items-center justify-center text-white">
                         <Loader2 size={48} className="animate-spin text-blue-500 mb-4" />
-                        <div className="text-xl font-bold">Switching Rendering Engine...</div>
-                        <div className="text-sm text-slate-400 mt-2">Flush Layout Cache & Optimizing Layers</div>
+                        <div className="text-xl font-bold">Optimizing Rendering...</div>
+                        <div className="text-sm text-slate-400 mt-2">Processing {ITEM_COUNT} Items</div>
                     </div>
                 )}
 
@@ -180,20 +197,7 @@ const ReflowRepaint = () => {
                     Object Count: {ITEM_COUNT}
                 </div>
 
-                {/* Test Items */}
-                {Array.from({ length: ITEM_COUNT }).map((_, i) => (
-                    <div
-                        key={i}
-                        className="test-item absolute w-6 h-6 rounded-full shadow-lg"
-                        style={{
-                            top: `${Math.random() * 90 + 5}%`, // 상하 여백 둠
-                            left: '50px',
-                            background: `hsl(${Math.random() * 360}, 70%, 60%)`,
-                            willChange: isOptimized ? 'transform' : 'auto',
-                            opacity: 0.8
-                        }}
-                    />
-                ))}
+                <TestItemLayer isOptimized={isOptimized} count={ITEM_COUNT} />
             </div>
         </div>
     );


### PR DESCRIPTION
## 📌 Description
브라우저 렌더링 파이프라인의 **Reflow(Layout)**와 **Repaint(Composite)** 단계의 성능 비용 차이를 증명하는 첫 번째 실험(Day 1)을 구현하고, 대량의 DOM 제어로 인해 발생한 UI 블로킹 문제를 최적화했습니다.

## 🛠️ Changes

### 1. 🧪 실험 기능 구현 (Core Feature)
- **CPU vs GPU 렌더링 비교:**
  - `left/top` 속성 변경 시 발생하는 Reflow 비용과 `transform` 변경 시의 GPU 가속 효율 차이를 시각적으로 구현.
  - 3,000개의 DOM 요소를 동시에 제어하며 `stats.js`를 통해 실시간 FPS 측정.
- **직관적인 UI:** 슬라이딩 토글 스위치와 상태별(CPU/GPU) 설명 배너 추가.

### 2. ⚡️ 성능 이슈 해결 (Optimization Report)
대량의 컴포넌트(3,000개) 상태 변경 시 UI가 멈추는 **Frame Drop(INP 지연)** 현상을 발견하고 해결함.

- **문제 (Problem):** - 렌더링 모드 전환 시 메인 스레드가 3,000개의 가상 DOM 비교(Diffing) 연산에 점유되어 토글 스위치 반응이 약 0.5초~1초간 지연됨.
- **해결 (Solution):**
  1. **`React.memo` 도입:** 아이템 렌더링 부를 별도 컴포넌트로 분리하고 메모이제이션하여, 불필요한 부모 리렌더링 전파를 차단.
  2. **`useTransition` (Concurrency) 적용:** 무거운 렌더링 작업을 낮은 우선순위로 미루고, UI(로딩 스피너)를 먼저 갱신하여 **Non-blocking UI** 경험 제공.

## 📸 Screenshots
![KakaoTalk_20260113_191150433](https://github.com/user-attachments/assets/0b1b63cf-dd21-4a4c-bdd2-ff61d7916d25)
![KakaoTalk_20260113_191150433_01](https://github.com/user-attachments/assets/e16b0eff-79de-419c-b2d8-62be15dd7b8a)


## 🔗 Related Issue
Closes #3